### PR TITLE
fix(rtk): invoke TLA functions with default arguments without explicit TLAs

### DIFF
--- a/cmds/rtk/src/eval.rs
+++ b/cmds/rtk/src/eval.rs
@@ -368,12 +368,9 @@ main{}
 			.map_err(|e| anyhow::anyhow!("evaluation error:\n{}", e))?
 	};
 
-	// Apply TLA if specified
-	let result = if !opts.tla_str.is_empty() || !opts.tla_code.is_empty() {
-		apply_tla(state, result, opts)?
-	} else {
-		result
-	};
+	// Apply TLA - always attempt to invoke if result is a function
+	// This handles both explicit TLAs and functions with default arguments
+	let result = apply_tla(state, result, opts)?;
 
 	// Manifest the result to JSON
 	let manifest = result

--- a/cmds/rtk/testdata/test-export-tla-defaults/main.jsonnet
+++ b/cmds/rtk/testdata/test-export-tla-defaults/main.jsonnet
@@ -1,0 +1,31 @@
+// This file is a function with default arguments
+// It should be callable without providing TLAs
+function(mode='default', replicas=1) {
+  deployment: {
+    apiVersion: 'apps/v1',
+    kind: 'Deployment',
+    metadata: {
+      name: 'tla-defaults-deployment',
+      namespace: 'tla-test',
+    },
+    spec: {
+      replicas: replicas,
+      selector: {
+        matchLabels: {
+          mode: mode,
+        },
+      },
+    },
+  },
+  configmap: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'tla-defaults-config',
+      namespace: 'tla-test',
+    },
+    data: {
+      mode: mode,
+    },
+  },
+}

--- a/cmds/rtk/testdata/test-export-tla-defaults/spec.json
+++ b/cmds/rtk/testdata/test-export-tla-defaults/spec.json
@@ -1,0 +1,11 @@
+{
+    "apiVersion": "tanka.dev/v1alpha1",
+    "kind": "Environment",
+    "metadata": {
+        "name": "tla-defaults-env"
+    },
+    "spec": {
+        "apiServer": "https://localhost",
+        "namespace": "tla-test"
+    }
+}


### PR DESCRIPTION
## Summary

- Fix "tried to manifest function" error when exporting environments where the main.jsonnet is a function with default arguments
- Previously, rtk only called `apply_tla` when explicit TLAs were provided via `--tla-str` or `--tla-code`
- Now `apply_tla` is always called, which correctly handles functions with default arguments

## Test plan

- [x] Added `test_export_tla_function_with_defaults` - verifies export works without providing TLAs when the function has defaults
- [x] Added `test_export_tla_function_with_overrides` - verifies TLAs can still override the defaults
- [x] All existing rtk tests pass
- [x] Manually tested with real environment that was failing before