### PR TITLE
Add rtk validate environments command

### DIFF
--- a/cmds/rtk/src/commands/validate/common.rs
+++ b/cmds/rtk/src/commands/validate/common.rs
@@ -3,6 +3,7 @@
 use std::{
 	cell::RefCell,
 	collections::{HashMap, HashSet},
+	fs,
 	path::{Path, PathBuf},
 	sync::Arc,
 };
@@ -90,6 +91,18 @@ pub fn collect_validation_files(dir: &Path) -> Result<Vec<PathBuf>> {
 
 	files.sort();
 	Ok(files)
+}
+
+/// Returns true if any validation file in `dir` defines `namespaceTest`.
+pub fn any_validation_defines_namespace_test(dir: &Path) -> Result<bool> {
+	for path in collect_validation_files(dir)? {
+		let content = fs::read_to_string(&path)
+			.with_context(|| format!("reading validation file {}", path.display()))?;
+		if content.contains("namespaceTest") {
+			return Ok(true);
+		}
+	}
+	Ok(false)
 }
 
 /// Collect test files (*_test.jsonnet) from a directory.

--- a/cmds/rtk/src/commands/validate/environments.rs
+++ b/cmds/rtk/src/commands/validate/environments.rs
@@ -1,0 +1,141 @@
+//! Validate environments command — export environments in memory, then run validations.
+
+use std::{
+	io::Write,
+	path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use clap::Args;
+use rayon::prelude::*;
+use tracing::debug;
+
+use super::{common, manifests};
+use crate::environments::{
+	discover::Discover,
+	export::{export_discovered_env_in_memory, ExportOpts, MemoryManifest},
+};
+use crate::jsonnet::evaluator::{DefaultEvaluator, Evaluator};
+
+#[derive(Args)]
+pub struct EnvironmentsArgs {
+	/// Tanka environment paths to export and validate
+	#[arg(required = true)]
+	pub environments: Vec<PathBuf>,
+
+	/// Directory containing Jsonnet validation files
+	#[arg(long)]
+	pub tests_dir: String,
+
+	/// Log the N slowest work items at the end of the run
+	#[arg(long)]
+	pub log_slowest: Option<usize>,
+
+	/// Regex filter on '<kind>/<name>'. See https://tanka.dev/output-filtering
+	#[arg(short = 't', long)]
+	pub target: Vec<String>,
+
+	#[command(flatten)]
+	pub jsonnet: super::super::JsonnetArgs,
+}
+
+/// Run the validate environments command.
+pub fn run<W: Write>(args: EnvironmentsArgs, mut writer: W) -> Result<()> {
+	let tests_dir = PathBuf::from(&args.tests_dir);
+
+	debug!(
+		environments = ?args.environments.iter().map(|p| p.display().to_string()).collect::<Vec<_>>(),
+		tests_dir = %tests_dir.display(),
+		"starting validate environments"
+	);
+
+	if args.environments.is_empty() {
+		anyhow::bail!("at least one environment path is required");
+	}
+	if !tests_dir.is_dir() {
+		anyhow::bail!("tests directory does not exist: {}", tests_dir.display());
+	}
+
+	if common::any_validation_defines_namespace_test(&tests_dir)? {
+		writeln!(
+			writer,
+			"WARN: one or more validation files define namespaceTest. Results may be inaccurate \
+			 when multiple environments target the same Kubernetes namespace. For that case, use \
+			 `rtk export` followed by `rtk validate manifests` instead."
+		)?;
+		writeln!(writer)?;
+	}
+
+	let eval_opts = args.jsonnet.into_global_evaluator_options();
+	let export_opts = ExportOpts {
+		output_dir: PathBuf::from("."), // unused for in-memory export
+		target: args.target,
+		eval_opts,
+		skip_manifest: true,
+		..ExportOpts::default()
+	};
+
+	let discover = Discover::new(
+		DefaultEvaluator::new(export_opts.eval_opts.clone()),
+		args.environments,
+	);
+	let discovered: Vec<_> = discover
+		.collect::<Result<Vec<_>>>()
+		.context("discovering environments")?;
+
+	if discovered.is_empty() {
+		anyhow::bail!("no Tanka environments found in the given paths");
+	}
+
+	writeln!(
+		writer,
+		"Exporting {} environment(s) in memory",
+		discovered.len()
+	)?;
+
+	let pool = rayon::ThreadPoolBuilder::new()
+		.num_threads(export_opts.parallelism)
+		.stack_size(8 * 1024 * 1024)
+		.build()
+		.context("building export thread pool")?;
+
+	let export_results: Vec<anyhow::Result<(String, Vec<MemoryManifest>)>> = pool.install(|| {
+		discovered
+			.par_iter()
+			.map(|env| {
+				let (env_namespace, manifests) =
+					export_discovered_env_in_memory(env, &export_opts)?;
+				Ok((env_namespace, manifests))
+			})
+			.collect()
+	});
+	jrsonnet_gcmodule::collect_thread_cycles();
+
+	let mut all_manifests = Vec::new();
+	for (idx, result) in export_results.into_iter().enumerate() {
+		let (env_namespace, memory_manifests) = result
+			.with_context(|| format!("exporting environment {}", discovered[idx].path.display()))?;
+		writeln!(
+			writer,
+			"  {}: {} manifest(s)",
+			env_namespace,
+			memory_manifests.len()
+		)?;
+		for MemoryManifest {
+			relative_path,
+			value,
+		} in memory_manifests
+		{
+			let source_file = join_source_path(&env_namespace, &relative_path);
+			all_manifests.push(manifests::parsed_manifest_from_json(source_file, value));
+		}
+	}
+	writeln!(writer)?;
+
+	manifests::run_on_manifests(all_manifests, &tests_dir, args.log_slowest, writer)
+}
+
+fn join_source_path(env_namespace: &str, relative_path: &Path) -> String {
+	let rel = relative_path.to_string_lossy().replace('\\', "/");
+	format!("{env_namespace}/{rel}")
+}

--- a/cmds/rtk/src/commands/validate/manifests.rs
+++ b/cmds/rtk/src/commands/validate/manifests.rs
@@ -43,7 +43,7 @@ pub struct ManifestsArgs {
 }
 
 /// A parsed manifest with its source file path and namespace.
-struct ParsedManifest {
+pub(crate) struct ParsedManifest {
 	/// Relative path of the source YAML file
 	source_file: String,
 	/// Kubernetes resource kind (e.g. "Deployment", "ConfigMap")
@@ -161,8 +161,6 @@ pub fn run<W: Write>(args: ManifestsArgs, mut writer: W) -> Result<()> {
 		"starting validate manifests"
 	);
 
-	let t_start = Instant::now();
-
 	if !export_dir.is_dir() {
 		anyhow::bail!("export directory does not exist: {}", export_dir.display());
 	}
@@ -187,6 +185,46 @@ pub fn run<W: Write>(args: ManifestsArgs, mut writer: W) -> Result<()> {
 		manifest_count = manifests.len(),
 		"collected manifests from export directory"
 	);
+
+	run_on_manifests(manifests, &tests_dir, args.log_slowest, writer)
+}
+
+/// Build a [`ParsedManifest`] from exported JSON (in-memory export path).
+pub(crate) fn parsed_manifest_from_json(
+	source_file: String,
+	value: serde_json::Value,
+) -> ParsedManifest {
+	let kind = value
+		.get("kind")
+		.and_then(|v| v.as_str())
+		.unwrap_or("")
+		.to_string();
+	let namespace = value
+		.pointer("/metadata/namespace")
+		.and_then(|v| v.as_str())
+		.unwrap_or("")
+		.to_string();
+	ParsedManifest {
+		source_file,
+		kind,
+		namespace,
+		value,
+	}
+}
+
+/// Run validation rules against an already-collected manifest set.
+pub(crate) fn run_on_manifests<W: Write>(
+	manifests: Vec<ParsedManifest>,
+	tests_dir: &Path,
+	log_slowest: Option<usize>,
+	mut writer: W,
+) -> Result<()> {
+	let t_start = Instant::now();
+
+	if manifests.is_empty() {
+		writeln!(writer, "No manifests to validate")?;
+		return Ok(());
+	}
 
 	// Step 2: Collect validation files (*.jsonnet, excluding *_test.jsonnet)
 	let validation_files = common::collect_validation_files(&tests_dir)?;
@@ -219,7 +257,7 @@ pub fn run<W: Write>(args: ManifestsArgs, mut writer: W) -> Result<()> {
 
 	// Step 4: Pre-process validation files (extract kinds, resolve paths)
 	let t_preprocess = Instant::now();
-	let import_paths = vec![tests_dir.clone()];
+	let import_paths = vec![tests_dir.to_path_buf()];
 	let mut validation_infos = Vec::new();
 
 	for validation_file in &validation_files {
@@ -545,7 +583,7 @@ pub fn run<W: Write>(args: ManifestsArgs, mut writer: W) -> Result<()> {
 
 	// Execute all batched work items in parallel
 	let t_eval = Instant::now();
-	let slowest_tracker = args.log_slowest.map(SlowestTracker::new);
+	let slowest_tracker = log_slowest.map(SlowestTracker::new);
 	let results: Vec<TestResult> = work_items
 		.into_par_iter()
 		.flat_map_iter(|item| {

--- a/cmds/rtk/src/commands/validate/mod.rs
+++ b/cmds/rtk/src/commands/validate/mod.rs
@@ -10,7 +10,8 @@
 //! |------------|---------|
 //! | `lint`     | Check that validation files are syntactically valid and well-formed |
 //! | `test`     | Run unit tests for the validation rules themselves |
-//! | `manifests`| Run validation rules against real exported manifests |
+//! | `manifests`   | Run validation rules against real exported manifests |
+//! | `environments`| Export environments in memory, then run validations |
 //!
 //! # Directory layout
 //!
@@ -118,6 +119,9 @@
 //!
 //! # 4. Same, but recursively walk subdirectories in the export dir
 //! rtk validate manifests ./export-output --recursive --tests-dir ./validations
+//!
+//! # 5. Export environments in memory and validate (no export directory needed)
+//! rtk validate environments ./env-a ./env-b --tests-dir ./validations
 //! ```
 
 use std::io::Write;
@@ -126,6 +130,7 @@ use anyhow::Result;
 use clap::{Args, Subcommand};
 
 pub mod common;
+pub mod environments;
 pub mod lint;
 pub mod manifests;
 pub mod test;
@@ -141,6 +146,9 @@ pub enum ValidateCommands {
 	/// Validate exported manifests against validation files
 	Manifests(manifests::ManifestsArgs),
 
+	/// Export environments in memory and validate their manifests
+	Environments(environments::EnvironmentsArgs),
+
 	/// Check that validation files are valid Jsonnet and define required functions
 	Lint(lint::LintArgs),
 
@@ -152,6 +160,9 @@ pub enum ValidateCommands {
 pub fn run<W: Write>(args: ValidateArgs, writer: W) -> Result<()> {
 	match args.command {
 		ValidateCommands::Manifests(manifests_args) => manifests::run(manifests_args, writer),
+		ValidateCommands::Environments(environments_args) => {
+			environments::run(environments_args, writer)
+		}
 		ValidateCommands::Lint(lint_args) => lint::run(lint_args, writer),
 		ValidateCommands::Test(test_args) => test::run(test_args, writer),
 	}

--- a/cmds/rtk/src/environments/export.rs
+++ b/cmds/rtk/src/environments/export.rs
@@ -194,6 +194,15 @@ pub struct ExportTimingData {
 	pub manifest_count: usize,
 }
 
+/// A manifest produced by an in-memory export (post-injection, JSON).
+#[derive(Debug, Clone)]
+pub struct MemoryManifest {
+	/// Path relative to the environment export root (same layout as `rtk export`)
+	pub relative_path: PathBuf,
+	/// Manifest after namespace/label injection and metadata cleanup
+	pub value: JsonValue,
+}
+
 /// Result of exporting a single environment
 #[derive(Debug)]
 pub struct ExportEnvResult {
@@ -507,14 +516,19 @@ pub fn export(paths: &[PathBuf], opts: ExportOpts) -> Result<ExportResult> {
 					);
 				}
 
-				let result = match export_single_env(&env, opts) {
-					Ok((files, namespace, timing)) => ExportEnvResult {
-						env_path: env.path.clone(),
-						files_written: files,
-						env_namespace: Some(namespace),
-						error: None,
-						timing: if show_timing { Some(timing) } else { None },
-					},
+				let result = match export_single_env(&env, opts, ExportDestination::Disk) {
+					Ok((ExportSingleEnvOutput::Disk(files), namespace, timing)) => {
+						ExportEnvResult {
+							env_path: env.path.clone(),
+							files_written: files,
+							env_namespace: Some(namespace),
+							error: None,
+							timing: if show_timing { Some(timing) } else { None },
+						}
+					}
+					Ok((ExportSingleEnvOutput::Memory(_), _, _)) => {
+						unreachable!("disk export must not return memory manifests")
+					}
 					Err(ExportError::Fatal(msg)) => {
 						abort.store(true, Ordering::Relaxed);
 						ExportEnvResult {
@@ -749,12 +763,43 @@ fn count_environment_objects(value: &JsonValue) -> usize {
 	count
 }
 
+/// Export a single environment to memory (no filesystem writes).
+///
+/// Returns `(environment_namespace, manifests)` where `environment_namespace` matches
+/// the key used in export `manifest.json` (path to `main.jsonnet`, usually relative to cwd).
+pub fn export_discovered_env_in_memory(
+	env: &Discovered,
+	opts: &ExportOpts,
+) -> Result<(String, Vec<MemoryManifest>)> {
+	match export_single_env(env, opts, ExportDestination::Memory) {
+		Ok((ExportSingleEnvOutput::Memory(manifests), env_namespace, _timing)) => {
+			Ok((env_namespace, manifests))
+		}
+		Ok((ExportSingleEnvOutput::Disk(_), _, _)) => {
+			unreachable!("memory export must not return disk paths")
+		}
+		Err(ExportError::Fatal(msg)) => bail!("{}", msg),
+		Err(ExportError::EnvError(_, msg)) => bail!("{}", msg),
+	}
+}
+
+enum ExportDestination {
+	Disk,
+	Memory,
+}
+
+enum ExportSingleEnvOutput {
+	Disk(Vec<PathBuf>),
+	Memory(Vec<MemoryManifest>),
+}
+
 /// Export a single environment
-/// Returns (files_written, environment_namespace, timing_data)
+/// Returns (files_written or memory manifests, environment_namespace, timing_data)
 fn export_single_env(
 	env: &Discovered,
 	opts: &ExportOpts,
-) -> Result<(Vec<PathBuf>, String, ExportTimingData), ExportError> {
+	destination: ExportDestination,
+) -> Result<(ExportSingleEnvOutput, String, ExportTimingData), ExportError> {
 	use std::time::Instant;
 
 	let env_start = Instant::now();
@@ -849,15 +894,22 @@ fn export_single_env(
 
 	if environments.is_empty() {
 		trace!("[{}] No environments to process, skipping", env_display);
-		return Ok((vec![], env_namespace, timing));
+		let empty = match destination {
+			ExportDestination::Disk => ExportSingleEnvOutput::Disk(vec![]),
+			ExportDestination::Memory => ExportSingleEnvOutput::Memory(vec![]),
+		};
+		return Ok((empty, env_namespace, timing));
 	}
 
-	// Use output directory directly (matching tk behavior)
-	// Note: tk writes directly to output_dir without creating env subdirectories
-	fs::create_dir_all(&opts.output_dir)
-		.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
+	if matches!(destination, ExportDestination::Disk) {
+		// Use output directory directly (matching tk behavior)
+		// Note: tk writes directly to output_dir without creating env subdirectories
+		fs::create_dir_all(&opts.output_dir)
+			.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
+	}
 
 	let mut files_written = Vec::new();
+	let mut memory_manifests = Vec::new();
 
 	// Process each Environment's manifests separately (matching Tanka's approach)
 	// This avoids loading all manifests into memory at once
@@ -1030,30 +1082,10 @@ fn export_single_env(
 					}
 				}
 
-				// Serialize manifest (CPU-intensive, good for parallelization)
-				// Always output YAML regardless of extension (matching tk behavior)
 				// Sort all object keys to match Go's yaml.v3 output order
 				let sorted_manifest = sort_json_keys(manifest);
 
-				// Use serializer options to match Go's yaml.v2 output (used by tk for manifest export)
-				let options = serde_saphyr::SerializerOptions {
-					indent_step: 2,
-					indent_array: Some(0),
-					prefer_block_scalars: true,
-					empty_map_as_braces: true,
-					empty_array_as_brackets: true,
-					line_width: Some(80),
-					scientific_notation_threshold: Some(1000000), // 1 million
-					scientific_notation_small_threshold: Some(0.0001), // Small floats like 0.00001 become 1e-05
-					quote_ambiguous_keys: true,                   // Quote y, n, yes, no, etc. to match Go yaml.v3
-					quote_numeric_strings: true, // Quote numeric string keys like "12", "12.5" to match Go yaml.v3
-					..Default::default()
-				};
-				let mut content = String::new();
-				serde_saphyr::to_fmt_writer_with_options(&mut content, &sorted_manifest, options)
-					.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
-
-				Ok((relative_path, content))
+				Ok((relative_path, sorted_manifest))
 			})
 			.collect();
 
@@ -1069,79 +1101,95 @@ fn export_single_env(
 			serialize_start.elapsed().as_millis() as f64 / manifest_count as f64
 		);
 
-		// Phase 2: Write files (I/O-bound, kept sequential for directory coordination)
-		// Note: File writes could also be parallelized with proper directory creation synchronization
-		trace!(
-			"[{}:{}] Starting sequential file writes for {} files",
-			env_display,
-			env_name,
-			manifest_count
-		);
-		let write_start = Instant::now();
-		let mut files_skipped = 0usize;
-		for (relative_path, content) in processed_manifests {
-			let filepath = opts.output_dir.join(&relative_path);
-
-			// Create parent directories if needed
-			if let Some(parent) = filepath.parent() {
-				fs::create_dir_all(parent)
-					.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
-			}
-
-			// PERFORMANCE: Skip write if file exists with identical content
-			// This is a significant optimization for re-exports where most files don't change.
-			// On slow storage (e.g., EBS), reading to compare is much faster than writing.
-			if filepath.exists() {
-				if let Ok(existing_content) = fs::read_to_string(&filepath) {
-					if existing_content == content {
-						files_written.push(relative_path);
-						files_skipped += 1;
-						continue;
-					}
+		match destination {
+			ExportDestination::Memory => {
+				for (relative_path, value) in processed_manifests {
+					memory_manifests.push(MemoryManifest {
+						relative_path,
+						value,
+					});
 				}
-				// File exists but content differs or couldn't be read - will be overwritten
 			}
+			ExportDestination::Disk => {
+				// Phase 2: Write files (I/O-bound, kept sequential for directory coordination)
+				trace!(
+					"[{}:{}] Starting sequential file writes for {} files",
+					env_display,
+					env_name,
+					manifest_count
+				);
+				let write_start = Instant::now();
+				let mut files_skipped = 0usize;
+				for (relative_path, sorted_manifest) in processed_manifests {
+					// Serialize manifest (CPU-intensive). Always output YAML regardless of
+					// extension (matching tk behavior).
+					let options = serde_saphyr::SerializerOptions {
+						indent_step: 2,
+						indent_array: Some(0),
+						prefer_block_scalars: true,
+						empty_map_as_braces: true,
+						empty_array_as_brackets: true,
+						line_width: Some(80),
+						scientific_notation_threshold: Some(1000000),
+						scientific_notation_small_threshold: Some(0.0001),
+						quote_ambiguous_keys: true,
+						quote_numeric_strings: true,
+						..Default::default()
+					};
+					let mut content = String::new();
+					serde_saphyr::to_fmt_writer_with_options(
+						&mut content,
+						&sorted_manifest,
+						options,
+					)
+					.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
 
-			// PERFORMANCE: Use BufWriter to reduce syscall overhead
-			//
-			// Without BufWriter, each write_all() would result in a direct write() syscall.
-			// BufWriter batches small writes into 8KB chunks (default buffer size),
-			// significantly reducing kernel transitions for typical manifest files (2-20KB).
-			//
-			// Benchmark context:
-			// - Direct write: ~1 syscall per file
-			// - BufWriter: ~1-3 syscalls per file (depending on size)
-			// - For 2800 files: saves ~2000+ syscalls
-			//
-			// The buffer is automatically flushed when the writer is dropped.
-			use std::io::Write;
-			let file = fs::File::create(&filepath)
-				.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
-			let mut writer = std::io::BufWriter::new(file);
-			writer
-				.write_all(content.as_bytes())
-				.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
+					let filepath = opts.output_dir.join(&relative_path);
 
-			// Track relative path for manifest.json
-			files_written.push(relative_path);
+					if let Some(parent) = filepath.parent() {
+						fs::create_dir_all(parent)
+							.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
+					}
+
+					if filepath.exists() {
+						if let Ok(existing_content) = fs::read_to_string(&filepath) {
+							if existing_content == content {
+								files_written.push(relative_path);
+								files_skipped += 1;
+								continue;
+							}
+						}
+					}
+
+					use std::io::Write;
+					let file = fs::File::create(&filepath)
+						.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
+					let mut writer = std::io::BufWriter::new(file);
+					writer
+						.write_all(content.as_bytes())
+						.map_err(|e| ExportError::EnvError(env.path.clone(), e.to_string()))?;
+
+					files_written.push(relative_path);
+				}
+				if files_skipped > 0 {
+					trace!(
+						"[{}:{}] Skipped {} unchanged files",
+						env_display,
+						env_name,
+						files_skipped
+					);
+				}
+				timing.write_ms += write_start.elapsed().as_millis();
+				trace!(
+					"[{}:{}] File writes completed in {}ms ({} files, {:.2}ms/file)",
+					env_display,
+					env_name,
+					write_start.elapsed().as_millis(),
+					manifest_count,
+					write_start.elapsed().as_millis() as f64 / manifest_count as f64
+				);
+			}
 		}
-		if files_skipped > 0 {
-			trace!(
-				"[{}:{}] Skipped {} unchanged files",
-				env_display,
-				env_name,
-				files_skipped
-			);
-		}
-		timing.write_ms += write_start.elapsed().as_millis();
-		trace!(
-			"[{}:{}] File writes completed in {}ms ({} files, {:.2}ms/file)",
-			env_display,
-			env_name,
-			write_start.elapsed().as_millis(),
-			manifest_count,
-			write_start.elapsed().as_millis() as f64 / manifest_count as f64
-		);
 	}
 
 	debug!(
@@ -1151,7 +1199,11 @@ fn export_single_env(
 		env_start.elapsed().as_millis()
 	);
 
-	Ok((files_written, env_namespace, timing))
+	let output = match destination {
+		ExportDestination::Disk => ExportSingleEnvOutput::Disk(files_written),
+		ExportDestination::Memory => ExportSingleEnvOutput::Memory(memory_manifests),
+	};
+	Ok((output, env_namespace, timing))
 }
 
 /// Export manifest file that maps exported files to their environment

--- a/cmds/rtk/tests/validate_test.rs
+++ b/cmds/rtk/tests/validate_test.rs
@@ -1,8 +1,8 @@
-//! Integration tests for the validate command (manifests, lint, test).
+//! Integration tests for the validate command (manifests, lint, test, environments).
 
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
-use rtk::commands::validate::{lint, manifests, test as validate_test};
+use rtk::commands::validate::{environments, lint, manifests, test as validate_test};
 
 fn testdata_path(subpath: &str) -> PathBuf {
 	PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -788,6 +788,172 @@ mod test_runner_tests {
 		assert!(
 			output_str.contains("check_namespace_test.jsonnet"),
 			"should run namespace tests: {}",
+			output_str
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// validate environments
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod environments_tests {
+	use super::*;
+	use rtk::jsonnet::evaluator::EvaluatorImplementation;
+
+	fn default_jsonnet_args() -> rtk::commands::JsonnetArgs {
+		rtk::commands::JsonnetArgs {
+			ext_code: vec![],
+			ext_str: vec![],
+			implementation: EvaluatorImplementation::default(),
+			max_stack: 500,
+			tla_code: vec![],
+			tla_str: vec![],
+		}
+	}
+
+	fn export_testdata_path(subpath: &str) -> PathBuf {
+		PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+			.join("testdata")
+			.join(subpath)
+	}
+
+	#[test]
+	fn test_environments_exports_and_validates() {
+		let temp = tempfile::TempDir::new().unwrap();
+		fs::write(temp.path().join("jsonnetfile.json"), "{}").unwrap();
+		let env_dir = temp.path().join("env");
+		fs::create_dir_all(&env_dir).unwrap();
+		fs::write(
+			env_dir.join("spec.json"),
+			r#"{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": { "name": "test" },
+  "spec": { "namespace": "default" }
+}"#,
+		)
+		.unwrap();
+		fs::write(
+			env_dir.join("main.jsonnet"),
+			r#"{
+  cm: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: { name: 'ok', namespace: 'default', labels: { app: 'x' } },
+  },
+}"#,
+		)
+		.unwrap();
+
+		let args = environments::EnvironmentsArgs {
+			environments: vec![env_dir],
+			tests_dir: testdata_path("manifests_test/validations")
+				.to_string_lossy()
+				.to_string(),
+			log_slowest: None,
+			target: vec![],
+			jsonnet: default_jsonnet_args(),
+		};
+
+		let mut output = Vec::new();
+		let result = environments::run(args, &mut output);
+		let output_str = String::from_utf8(output).unwrap();
+
+		assert!(result.is_ok(), "should pass: {}", output_str);
+		assert!(
+			output_str.contains("Exporting 1 environment(s) in memory"),
+			"should report in-memory export: {}",
+			output_str
+		);
+		assert!(
+			output_str.contains("0 failed"),
+			"should have no failures: {}",
+			output_str
+		);
+	}
+
+	#[test]
+	fn test_environments_warns_on_namespace_test() {
+		let temp = tempfile::TempDir::new().unwrap();
+		fs::write(temp.path().join("jsonnetfile.json"), "{}").unwrap();
+		let env_dir = temp.path().join("env");
+		fs::create_dir_all(&env_dir).unwrap();
+		fs::write(
+			env_dir.join("spec.json"),
+			r#"{
+  "apiVersion": "tanka.dev/v1alpha1",
+  "kind": "Environment",
+  "metadata": { "name": "test" },
+  "spec": { "namespace": "default" }
+}"#,
+		)
+		.unwrap();
+		fs::write(
+			env_dir.join("main.jsonnet"),
+			r#"{
+  cm: {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: { name: 'ok', namespace: 'default' },
+  },
+}"#,
+		)
+		.unwrap();
+
+		let args = environments::EnvironmentsArgs {
+			environments: vec![env_dir],
+			tests_dir: testdata_path("manifests_test/validations")
+				.to_string_lossy()
+				.to_string(),
+			log_slowest: None,
+			target: vec![],
+			jsonnet: default_jsonnet_args(),
+		};
+
+		let mut output = Vec::new();
+		let _ = environments::run(args, &mut output);
+		let output_str = String::from_utf8(output).unwrap();
+
+		assert!(
+			output_str.contains("namespaceTest")
+				&& output_str.contains("rtk export")
+				&& output_str.contains("rtk validate manifests"),
+			"should warn about namespaceTest accuracy: {}",
+			output_str
+		);
+	}
+
+	#[test]
+	fn test_environments_real_fixture() {
+		let mut jsonnet = default_jsonnet_args();
+		jsonnet.ext_str = vec![
+			("deploymentName".into(), "dep".into()),
+			("serviceName".into(), "svc".into()),
+		];
+		let args = environments::EnvironmentsArgs {
+			environments: vec![export_testdata_path("test-export-envs/static-env")],
+			tests_dir: testdata_path("manifests_test/validations")
+				.to_string_lossy()
+				.to_string(),
+			log_slowest: None,
+			target: vec![],
+			jsonnet,
+		};
+
+		let mut output = Vec::new();
+		let result = environments::run(args, &mut output);
+		let output_str = String::from_utf8(output).unwrap();
+
+		// static-env Deployment/Service lack labels; check_labels should fail
+		assert!(
+			result.is_err(),
+			"should fail without labels: {}",
+			output_str
+		);
+		assert!(
+			output_str.contains("missing labels"),
+			"should report label failure: {}",
 			output_str
 		);
 	}


### PR DESCRIPTION
## Summary

- Adds `rtk validate environments <env>... --tests-dir <dir>` to export each environment in memory and run the same validation rules as `validate manifests`, with manifests grouped per environment via distinct virtual source paths.
- Introduces `export_discovered_env_in_memory` so export injection/filename logic is reused without writing YAML to disk.
- Prints a warning when any validation file defines `namespaceTest`, since multiple environments targeting the same Kubernetes namespace should use `rtk export` then `rtk validate manifests` instead.


Made with [Cursor](https://cursor.com)