### PR TITLE
chore(docker): harden runtime image with distroless/cc nonroot base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
-# Runtime stage - using Ubuntu to match build environment glibc version
-FROM ubuntu:24.04
+# Runtime stage - distroless/cc-debian12.
+#
+# The rtk/jrsonnet binaries are built for *-unknown-linux-gnu and are
+# dynamically linked against glibc and libgcc_s.so.1 (verified via readelf:
+# NEEDED libc.so.6, libm.so.6, libgcc_s.so.1). distroless/cc is the smallest
+# distroless variant that ships both glibc and libgcc_s, so the binaries run
+# unmodified. scratch / distroless:static (no glibc) and distroless:base
+# (glibc but no libgcc_s) would fail at startup.
+#
+# Compared to the previous ubuntu:24.04 base this drops the shell, package
+# manager, and the rest of the OS userland, and pins the base by digest.
+# The :nonroot tag runs as UID/GID 65532 and ships ca-certificates.
+FROM gcr.io/distroless/cc-debian12:nonroot@sha256:bd2899c12b335c827750ccf2359879eab09c09b206023dcebea408947d54127c
 
 # Copy the pre-built binaries (copied to docker-bin/ by the workflow)
 COPY docker-bin/rtk /usr/local/bin/rtk
 COPY docker-bin/jrsonnet /usr/local/bin/jrsonnet
 
-# Create a non-root user for security
-RUN groupadd -r rtk && useradd -r -g rtk rtk
-USER rtk
+# distroless ships the nonroot user (UID/GID 65532); no useradd needed.
+USER nonroot:nonroot
 
 # Add labels for metadata
 ARG VERSION


### PR DESCRIPTION
## Summary

Replace the `ubuntu:24.04` runtime base with `gcr.io/distroless/cc-debian12:nonroot`, pinned by digest — bringing rustanka in line with the recent image hardening across [grafana-argo-workflows-ui#201](https://github.com/grafana/grafana-argo-workflows-ui/pull/201), [prometheus-cosmosdb-exporter#34](https://github.com/grafana/prometheus-cosmosdb-exporter/pull/34), and [crispy#159](https://github.com/grafana/crispy/pull/159).

- **distroless/cc, not scratch/static.** Unlike the Go projects above (static `CGO_ENABLED=0` binaries → `scratch`/`distroless:static`), rtk and jrsonnet are built for `*-unknown-linux-gnu` and are **dynamically linked against glibc**. `readelf -d` on the published `rtk-linux-amd64` shows `NEEDED libc.so.6`, `libm.so.6`, `libgcc_s.so.1` (and no `libssl` — TLS is rustls). `distroless/cc` is the smallest distroless variant shipping both glibc and `libgcc_s`, so the binaries run unmodified. `scratch` / `distroless:static` (no glibc) and `distroless:base` (glibc but no `libgcc_s`) would fail at startup.
- **Drops the OS userland.** No shell, no `apt`, no coreutils — far smaller CVE surface than the full Ubuntu base.
- **Pinned by digest** (`sha256:bd2899c…`, the multi-arch manifest covering `linux/amd64` + `linux/arm64`) instead of the previous floating `ubuntu:24.04` tag.
- **Nonroot retained, simplified.** The `:nonroot` tag runs as UID/GID 65532, so the manual `groupadd`/`useradd` is removed and replaced with an explicit `USER nonroot:nonroot`.
- **ca-certificates** are baked into the base (the bare `ubuntu:24.04` image did not ship them).

No build-system change — the release workflow still produces the same glibc binaries and copies them into `docker-bin/`.

## Test plan

- [ ] `docker build .` succeeds for `linux/amd64` and `linux/arm64`
- [ ] `docker run --rm <image> --help` prints rtk flags and exits cleanly as nonroot (this is the real gate — it proves glibc + `libgcc_s` resolve on `distroless/cc`)
- [ ] Smoke `rtk show` / `rtk eval` against a fixture so the rustls/k8s HTTPS path is exercised without a system OpenSSL
- [ ] Image scan shows no shell/apt packages and a reduced CVE count vs the ubuntu base

## Follow-up (not in this PR)

Reaching `scratch`-tier would require switching the release build to a static **musl** target (`*-unknown-linux-musl` + musl toolchain in `release.yaml`). Worth benchmarking first — musl's allocator is materially slower for jrsonnet's allocation-heavy workload, so it likely needs `mimalloc`/`jemalloc`. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)