### PR TITLE
feat(export): add --analyze-config function-call profiler

### DIFF
--- a/cmds/rtk/src/commands/export.rs
+++ b/cmds/rtk/src/commands/export.rs
@@ -1,12 +1,59 @@
 //! Export command handler.
 
-use std::{io::Write, path::PathBuf, sync::Arc};
+use std::{
+	fs,
+	io::Write,
+	path::{Path, PathBuf},
+	sync::Arc,
+};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Args;
+use serde::Deserialize;
 
 use super::common::UnimplementedArgs;
 use crate::environments::export::{self as export_impl, ExportMergeStrategy, ExportOpts};
+
+/// How to rank functions in the analysis report.
+#[derive(Debug, Clone, Copy, Default, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AnalyzeSortBy {
+	/// Inclusive (recursion-corrected) time, descending.
+	#[default]
+	Total,
+	/// Self time (excluding callees), descending.
+	#[serde(rename = "self")]
+	SelfTime,
+	/// Call count, descending.
+	Calls,
+}
+
+/// Configuration for `--analyze-config`, loaded from a JSON file.
+#[derive(Debug, Clone, Deserialize)]
+pub struct AnalyzeConfig {
+	/// Path to write the analysis report to (required).
+	pub output_file: PathBuf,
+	/// How to rank functions. Defaults to total time.
+	#[serde(default)]
+	pub sort_by: AnalyzeSortBy,
+	/// Only include functions whose total (inclusive) time is at least this
+	/// many milliseconds. Defaults to 0 (no filtering).
+	#[serde(default)]
+	pub total_time_threshold: f64,
+	/// Only include functions whose self time is at least this many
+	/// milliseconds. Defaults to 0 (no filtering).
+	#[serde(default)]
+	pub self_time_threshold: f64,
+}
+
+impl AnalyzeConfig {
+	fn load(path: &Path) -> Result<Self> {
+		let content = fs::read_to_string(path)
+			.with_context(|| format!("reading analyze config {}", path.display()))?;
+		serde_json::from_str(&content)
+			.with_context(|| format!("parsing analyze config {}", path.display()))
+	}
+}
 
 #[derive(Args)]
 pub struct ExportArgs {
@@ -77,6 +124,13 @@ pub struct ExportArgs {
 	#[arg(short = 't', long)]
 	pub target: Vec<String>,
 
+	/// Path to a JSON config enabling Jsonnet function-call profiling. The
+	/// config requires `output_file` and optionally accepts `sort_by`
+	/// ("total" (default), "self", or "calls"), `total_time_threshold`, and
+	/// `self_time_threshold` (both in milliseconds, default 0).
+	#[arg(long, value_name = "FILE")]
+	pub analyze_config: Option<PathBuf>,
+
 	#[command(flatten)]
 	pub jsonnet: super::JsonnetArgs,
 }
@@ -91,8 +145,22 @@ pub fn run<W: Write>(args: ExportArgs, mut writer: W) -> Result<()> {
 	}
 	.warn_if_set();
 
+	let analyze_config = match &args.analyze_config {
+		Some(path) => Some(AnalyzeConfig::load(path)?),
+		None => None,
+	};
+
 	let (paths, opts) = build_export_opts(args)?;
 	let result = export_impl::export(&paths, opts)?;
+
+	if let Some(config) = &analyze_config {
+		write_analysis_report(config)?;
+		writeln!(
+			writer,
+			"Function analysis written to {}",
+			config.output_file.display()
+		)?;
+	}
 
 	// Match tk behavior: silent on success, errors reported via the provided writer
 	// But report fatal errors prominently and summarize skipped ones
@@ -176,6 +244,135 @@ fn build_export_opts(args: ExportArgs) -> Result<(Vec<PathBuf>, ExportOpts)> {
 		merge_deleted_envs: args.merge_deleted_envs,
 		show_timing: false,
 		helm_cache: args.helm_cache,
+		analyze: args.analyze_config.is_some(),
 	};
 	Ok((paths, opts))
+}
+
+/// Format a nanosecond duration into a compact, human-readable string.
+fn format_ns(ns: u128) -> String {
+	if ns >= 1_000_000_000 {
+		format!("{:.2}s", ns as f64 / 1_000_000_000.0)
+	} else if ns >= 1_000_000 {
+		format!("{:.2}ms", ns as f64 / 1_000_000.0)
+	} else if ns >= 1_000 {
+		format!("{:.2}µs", ns as f64 / 1_000.0)
+	} else {
+		format!("{ns}ns")
+	}
+}
+
+/// Truncate `s` to `max` characters, keeping the right-hand side (most useful
+/// for file paths, where the filename is at the end).
+fn truncate_left(s: &str, max: usize) -> String {
+	if s.chars().count() <= max {
+		return s.to_string();
+	}
+	let tail: String = s
+		.chars()
+		.rev()
+		.take(max - 1)
+		.collect::<Vec<_>>()
+		.into_iter()
+		.rev()
+		.collect();
+	format!("…{tail}")
+}
+
+/// Truncate `s` to `max` characters, keeping the left-hand side.
+fn truncate_right(s: &str, max: usize) -> String {
+	if s.chars().count() <= max {
+		return s.to_string();
+	}
+	let head: String = s.chars().take(max - 1).collect();
+	format!("{head}…")
+}
+
+/// Write a ranked report of profiled Jsonnet function calls to the file
+/// configured in `config`.
+///
+/// Functions are ranked per `config.sort_by` (default: total inclusive,
+/// recursion-corrected time) and filtered by the configured time thresholds.
+/// Call count, self time (excluding callees), and the defining file (when
+/// known) are shown.
+fn write_analysis_report(config: &AnalyzeConfig) -> Result<()> {
+	let mut entries = jrsonnet_evaluator::profile::collect();
+	jrsonnet_evaluator::profile::set_enabled(false);
+
+	let total_threshold_ns = (config.total_time_threshold * 1_000_000.0).max(0.0) as u128;
+	let self_threshold_ns = (config.self_time_threshold * 1_000_000.0).max(0.0) as u128;
+	entries
+		.retain(|e| e.stat.total_ns >= total_threshold_ns && e.stat.self_ns >= self_threshold_ns);
+
+	match config.sort_by {
+		AnalyzeSortBy::Total => entries.sort_by(|a, b| {
+			b.stat
+				.total_ns
+				.cmp(&a.stat.total_ns)
+				.then_with(|| b.stat.count.cmp(&a.stat.count))
+		}),
+		AnalyzeSortBy::SelfTime => entries.sort_by(|a, b| {
+			b.stat
+				.self_ns
+				.cmp(&a.stat.self_ns)
+				.then_with(|| b.stat.count.cmp(&a.stat.count))
+		}),
+		AnalyzeSortBy::Calls => entries.sort_by(|a, b| {
+			b.stat
+				.count
+				.cmp(&a.stat.count)
+				.then_with(|| b.stat.total_ns.cmp(&a.stat.total_ns))
+		}),
+	}
+
+	let total_calls: u64 = entries.iter().map(|e| e.stat.count).sum();
+
+	const NAME_W: usize = 32;
+	const FILE_W: usize = 40;
+
+	let mut out = String::new();
+	out.push_str(&"=".repeat(96));
+	out.push('\n');
+	out.push_str(&format!(
+		"Function analysis ({} functions shown, {total_calls} total calls, sorted by {:?})\n",
+		entries.len(),
+		config.sort_by,
+	));
+	out.push_str(&"=".repeat(96));
+	out.push('\n');
+	out.push_str(&format!(
+		"{:<NAME_W$} {:<FILE_W$} {:>8} {:>10} {:>10}\n",
+		"FUNCTION", "FILE", "CALLS", "TOTAL", "SELF"
+	));
+	out.push_str(&"-".repeat(96));
+	out.push('\n');
+
+	for entry in &entries {
+		let file = entry.file.as_deref().unwrap_or("-");
+		out.push_str(&format!(
+			"{:<NAME_W$} {:<FILE_W$} {:>8} {:>10} {:>10}\n",
+			truncate_right(&entry.name, NAME_W),
+			truncate_left(file, FILE_W),
+			entry.stat.count,
+			format_ns(entry.stat.total_ns),
+			format_ns(entry.stat.self_ns),
+		));
+	}
+	out.push_str(&"=".repeat(96));
+	out.push('\n');
+
+	if let Some(parent) = config.output_file.parent() {
+		if !parent.as_os_str().is_empty() {
+			fs::create_dir_all(parent)
+				.with_context(|| format!("creating output directory {}", parent.display()))?;
+		}
+	}
+	fs::write(&config.output_file, out).with_context(|| {
+		format!(
+			"writing analysis report to {}",
+			config.output_file.display()
+		)
+	})?;
+
+	Ok(())
 }

--- a/cmds/rtk/src/environments/export.rs
+++ b/cmds/rtk/src/environments/export.rs
@@ -132,6 +132,8 @@ pub struct ExportOpts {
 	/// Maintain a `helm-cache/` metadata directory in the output dir to cache
 	/// `helmTemplate` results across runs and environments (experimental).
 	pub helm_cache: bool,
+	/// Profile Jsonnet function calls and print a ranked report after export.
+	pub analyze: bool,
 }
 
 impl Default for ExportOpts {
@@ -152,6 +154,7 @@ impl Default for ExportOpts {
 			merge_deleted_envs: vec![],
 			show_timing: false,
 			helm_cache: false,
+			analyze: false,
 		}
 	}
 }
@@ -329,6 +332,10 @@ pub fn export(paths: &[PathBuf], opts: ExportOpts) -> Result<ExportResult> {
 	use std::time::Instant;
 	let export_start = Instant::now();
 
+	if opts.analyze {
+		jrsonnet_evaluator::profile::set_enabled(true);
+	}
+
 	trace!(
 		"Starting export: {} paths, parallelism={}, output_dir={:?}",
 		paths.len(),
@@ -473,9 +480,16 @@ pub fn export(paths: &[PathBuf], opts: ExportOpts) -> Result<ExportResult> {
 	// Build a rayon thread pool with the requested parallelism.
 	// The lazy Discover iterator is consumed via par_bridge(), which pulls
 	// work items on-demand as pool threads become free.
+	// Profiling adds per-frame native stack cost, so give workers extra
+	// headroom for deeply recursive Jsonnet when --analyze-config is used.
+	let stack_size = if opts.analyze {
+		64 * 1024 * 1024
+	} else {
+		8 * 1024 * 1024
+	};
 	let pool = rayon::ThreadPoolBuilder::new()
 		.num_threads(opts.parallelism)
-		.stack_size(8 * 1024 * 1024)
+		.stack_size(stack_size)
 		.build()
 		.context("building export thread pool")?;
 

--- a/cmds/rtk/src/jsonnet/evaluator/jrsonnet/mod.rs
+++ b/cmds/rtk/src/jsonnet/evaluator/jrsonnet/mod.rs
@@ -400,6 +400,8 @@ impl JrsonnetEvaluator {
 		drop(result);
 		jrsonnet_gcmodule::collect_thread_cycles();
 
+		jrsonnet_evaluator::profile::flush_thread_local();
+
 		Ok(manifest)
 	}
 
@@ -424,6 +426,8 @@ impl JrsonnetEvaluator {
 
 		drop(result);
 		jrsonnet_gcmodule::collect_thread_cycles();
+
+		jrsonnet_evaluator::profile::flush_thread_local();
 
 		Ok(manifest.to_string())
 	}

--- a/cmds/rtk/tests/export_test.rs
+++ b/cmds/rtk/tests/export_test.rs
@@ -410,6 +410,7 @@ fn test_export_merge_strategies() {
 		merge_deleted_envs: vec![inline_env_path.to_string_lossy().into_owned()],
 		show_timing: false,
 		helm_cache: false,
+		analyze: false,
 	};
 
 	let result = export(&[(*static_envs[0].path).clone()], delete_opts).unwrap();

--- a/crates/jrsonnet-evaluator/src/function/mod.rs
+++ b/crates/jrsonnet-evaluator/src/function/mod.rs
@@ -185,21 +185,40 @@ impl FuncVal {
 		args: &dyn ArgsLike,
 		tailstrict: bool,
 	) -> Result<Val> {
-		match self {
+		// Profiling is gated by a single relaxed atomic. The whole body is kept
+		// in one stack frame (no helper call) to avoid adding native stack
+		// depth to deep Jsonnet recursion.
+		let profiling = crate::profile::is_enabled();
+		if profiling {
+			let name = self.name();
+			let file = match self {
+				Self::Normal(func) => Some(func.body.span().0.source_path().clone()),
+				_ => None,
+			};
+			crate::profile::enter(name, file);
+		}
+		let res = match self {
 			Self::Id => ID.call(call_ctx, loc, args),
-			Self::Normal(func) => {
-				let body_ctx = func.call_body_context(call_ctx, args, tailstrict)?;
-				evaluate(body_ctx, &func.body)
-			}
+			Self::Normal(func) => match func.call_body_context(call_ctx, args, tailstrict) {
+				Ok(body_ctx) => evaluate(body_ctx, &func.body),
+				Err(e) => Err(e),
+			},
 			Self::Thunk(thunk) => {
 				if args.is_empty() {
+					if profiling {
+						crate::profile::exit();
+					}
 					bail!(TooManyArgsFunctionHas(0, vec![],))
 				}
 				thunk.evaluate()
 			}
 			Self::StaticBuiltin(b) => b.call(call_ctx, loc, args),
 			Self::Builtin(b) => b.call(call_ctx, loc, args),
+		};
+		if profiling {
+			crate::profile::exit();
 		}
+		res
 	}
 	pub fn evaluate_simple<A: ArgsLike + OptionalContext>(
 		&self,

--- a/crates/jrsonnet-evaluator/src/lib.rs
+++ b/crates/jrsonnet-evaluator/src/lib.rs
@@ -19,6 +19,7 @@ mod integrations;
 pub mod manifest;
 mod map;
 mod obj;
+pub mod profile;
 pub mod stack;
 pub mod stdlib;
 mod tla;

--- a/crates/jrsonnet-evaluator/src/profile.rs
+++ b/crates/jrsonnet-evaluator/src/profile.rs
@@ -1,0 +1,180 @@
+//! Lightweight function-call profiler.
+//!
+//! Profiling is fully opt-in and gated behind a single relaxed atomic load, so
+//! the hot path is effectively free when disabled.
+//!
+//! While enabled, each thread accumulates per-function call counts and timings
+//! in thread-local storage (no locking on the hot path). Since interned strings
+//! ([`IStr`]) are not `Send`, names are converted to `String` only when a
+//! thread flushes its accumulated data into the global aggregate via
+//! [`flush_thread_local`]. The aggregate can then be read with [`collect`].
+
+use std::{
+	cell::RefCell,
+	sync::{
+		atomic::{AtomicBool, Ordering},
+		Mutex,
+	},
+	time::Instant,
+};
+
+use jrsonnet_interner::IStr;
+use jrsonnet_parser::SourcePath;
+use rustc_hash::FxHashMap;
+
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Per-function accumulated statistics.
+#[derive(Default, Clone, Copy)]
+pub struct FuncStat {
+	/// Number of times the function was called.
+	pub count: u64,
+	/// Wall-time spent in the function itself, excluding callees (nanoseconds).
+	pub self_ns: u128,
+	/// Inclusive wall-time spent in the function including callees
+	/// (nanoseconds).
+	///
+	/// For recursive functions, only the outermost frame on the stack
+	/// contributes, so a given slice of wall-time is counted once rather than
+	/// once per recursion level.
+	pub total_ns: u128,
+}
+
+/// Thread-local map key: function name plus the file it is defined in (when
+/// known; builtins have none). [`SourcePath`] is not `Send`, so it only lives
+/// in thread-local storage and is converted to a string at flush time.
+type ThreadKey = (IStr, Option<SourcePath>);
+
+struct Frame {
+	start: Instant,
+	/// Inclusive time spent in direct callees, used to derive self time.
+	child_ns: u128,
+	key: ThreadKey,
+	/// True when no ancestor frame is the same function (recursion guard for
+	/// inclusive time).
+	outermost: bool,
+}
+
+#[derive(Default)]
+struct ThreadProfile {
+	stats: FxHashMap<ThreadKey, FuncStat>,
+	stack: Vec<Frame>,
+	/// Active frame count per function, to detect recursion.
+	depth: FxHashMap<ThreadKey, u32>,
+}
+
+thread_local! {
+	static PROFILE: RefCell<ThreadProfile> = RefCell::new(ThreadProfile::default());
+}
+
+/// Aggregate key: function name and optional defining file path.
+type AggKey = (String, Option<String>);
+
+static AGGREGATE: Mutex<Option<FxHashMap<AggKey, FuncStat>>> = Mutex::new(None);
+
+/// Enable or disable profiling. Also resets the global aggregate when enabling.
+pub fn set_enabled(enabled: bool) {
+	if enabled {
+		*AGGREGATE.lock().expect("profile aggregate poisoned") = Some(FxHashMap::default());
+	}
+	ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// Whether profiling is currently enabled.
+#[inline(always)]
+pub fn is_enabled() -> bool {
+	ENABLED.load(Ordering::Relaxed)
+}
+
+/// Record entry into a function call named `name`, optionally defined in
+/// `file`. Must be paired with [`exit`].
+#[inline]
+pub fn enter(name: IStr, file: Option<SourcePath>) {
+	PROFILE.with(|p| {
+		let mut p = p.borrow_mut();
+		let key = (name, file);
+		let depth = p.depth.entry(key.clone()).or_insert(0);
+		let outermost = *depth == 0;
+		*depth += 1;
+		p.stack.push(Frame {
+			start: Instant::now(),
+			child_ns: 0,
+			key,
+			outermost,
+		});
+	});
+}
+
+/// Record exit from the most recently entered function call.
+#[inline]
+pub fn exit() {
+	PROFILE.with(|p| {
+		let mut p = p.borrow_mut();
+		let Some(frame) = p.stack.pop() else {
+			return;
+		};
+		let total_ns = frame.start.elapsed().as_nanos();
+		let self_ns = total_ns.saturating_sub(frame.child_ns);
+		if let Some(parent) = p.stack.last_mut() {
+			parent.child_ns += total_ns;
+		}
+		if let Some(depth) = p.depth.get_mut(&frame.key) {
+			*depth = depth.saturating_sub(1);
+		}
+		let entry = p.stats.entry(frame.key).or_default();
+		entry.count += 1;
+		entry.self_ns += self_ns;
+		if frame.outermost {
+			entry.total_ns += total_ns;
+		}
+	});
+}
+
+/// Flush this thread's accumulated stats into the global aggregate and clear
+/// the thread-local state. Cheap to call when profiling is disabled.
+pub fn flush_thread_local() {
+	PROFILE.with(|p| {
+		let mut p = p.borrow_mut();
+		p.stack.clear();
+		p.depth.clear();
+		if p.stats.is_empty() {
+			return;
+		}
+		let mut guard = AGGREGATE.lock().expect("profile aggregate poisoned");
+		if let Some(agg) = guard.as_mut() {
+			for ((name, file), stat) in p.stats.drain() {
+				let file = file.and_then(|p| p.path().map(|p| p.display().to_string()));
+				let entry = agg.entry((name.to_string(), file)).or_default();
+				entry.count += stat.count;
+				entry.self_ns += stat.self_ns;
+				entry.total_ns += stat.total_ns;
+			}
+		} else {
+			p.stats.clear();
+		}
+	});
+}
+
+/// A single profiled function: name, optional defining file, and stats.
+pub struct ProfileEntry {
+	pub name: String,
+	pub file: Option<String>,
+	pub stat: FuncStat,
+}
+
+/// Read the merged profiling results gathered so far.
+pub fn collect() -> Vec<ProfileEntry> {
+	let guard = AGGREGATE.lock().expect("profile aggregate poisoned");
+	guard
+		.as_ref()
+		.map(|agg| {
+			agg.iter()
+				.map(|((name, file), stat)| ProfileEntry {
+					name: name.clone(),
+					file: file.clone(),
+					stat: *stat,
+				})
+				.collect()
+		})
+		.unwrap_or_default()
+}


### PR DESCRIPTION
## Summary

Add an opt-in Jsonnet function-call profiler to `rtk export` so it's easy to see which functions dominate an evaluation. Enable it with `--analyze-config <file.json>`, where the config selects how results are ranked and where they're written.

- `output_file` (required), plus optional `sort_by` (`total` (default), `self`, `calls`), `total_time_threshold`, and `self_time_threshold` (both in milliseconds, default `0`)
- Report ranks functions and shows call count, inclusive total time, self time, and the defining file when known
- Zero overhead when the flag is absent: the hot path is gated by a single relaxed atomic load

### Context

The single choke point for every Jsonnet call (`FuncVal::evaluate`) is wrapped with enter/exit timing. Each worker thread accumulates per-function counts and timings in thread-local storage and merges into a shared aggregate once per environment evaluation, so there's no per-call locking and the parallel export path stays fast.

Inclusive ("total") time is recursion-corrected: only the outermost frame of a given function on the stack contributes, so a recursive helper isn't counted once per stack level. Without this, a deeply recursive tokenizer showed a nonsensical 277s total (far above wall-clock); after the fix its caller correctly ranks above it and the numbers reflect the real call hierarchy.

Made with [Cursor](https://cursor.com)