### PR TITLE
fix(helm): skip OCI repos in helm_repo_update

### DIFF
--- a/cmds/rtk/src/commands/tool/helm_exec.rs
+++ b/cmds/rtk/src/commands/tool/helm_exec.rs
@@ -90,9 +90,17 @@ fn chart_pull_path(chart: &str, repos: &[Repo]) -> String {
 	chart.to_string()
 }
 
-/// Run helm repo update.
+/// Run helm repo update, skipping OCI registries which do not use index-based updates.
 pub fn helm_repo_update(repos: &[Repo]) -> Result<()> {
-	let repo_file = write_repo_tmp_file(repos)?;
+	let repos: Vec<Repo> = repos
+		.iter()
+		.filter(|r| !r.url.starts_with("oci://"))
+		.cloned()
+		.collect();
+	if repos.is_empty() {
+		return Ok(());
+	}
+	let repo_file = write_repo_tmp_file(&repos)?;
 	let out = Command::new(helm_bin())
 		.args([
 			"repo",

--- a/cmds/rtk/tests/charts_test.rs
+++ b/cmds/rtk/tests/charts_test.rs
@@ -184,6 +184,28 @@ fn test_config_output_matches_manifest() {
 	assert_eq!(parsed.requires.len(), loaded.requires.len());
 }
 
+// ----- OCI repo update (no helm binary needed) -----
+
+#[test]
+fn test_repo_update_oci_only_skips_helm() {
+	use rtk::commands::tool::helm_exec::helm_repo_update;
+
+	let repos = vec![
+		Repo {
+			name: "karpenter".to_string(),
+			url: "oci://public.ecr.aws/karpenter".to_string(),
+			..Default::default()
+		},
+		Repo {
+			name: "jetstack".to_string(),
+			url: "oci://quay.io/jetstack/charts".to_string(),
+			..Default::default()
+		},
+	];
+	// Should return Ok without invoking helm, since all repos are OCI
+	helm_repo_update(&repos).unwrap();
+}
+
 // ----- Tests that require helm + network (ignored by default) -----
 
 #[test]


### PR DESCRIPTION
## Summary
`helm_repo_update` passes all repos to `helm repo update`, including OCI registries (`oci://`). OCI registries don't use the index-based update flow — they're pulled directly by URL — so `helm repo update` fails with `invalid reference` when it encounters one.

This filters out OCI repos before calling `helm repo update` and returns early if no non-OCI repos remain. `helm_pull` already handles OCI correctly via `chart_pull_path`, so this only affects the update step.

Affects any chartfile using OCI repos (e.g. karpenter, cert-manager, envoy-gateway, kepler, tinkerbell in deployment_tools).

## Test
- Added `test_repo_update_oci_only_skips_helm` — passes only OCI repos to `helm_repo_update`, asserts `Ok(())` without needing `helm` on PATH
- Verified locally with `rtk tool charts vendor` against the deployment_tools karpenter chartfile (two OCI chart versions)

```
cargo test -p rtk --test charts_test test_repo_update_oci_only_skips_helm
```