### PR TITLE
fix(apply): preserve kube API error details on apply/prune failures

### DIFF
--- a/cmds/rtk/src/commands/apply.rs
+++ b/cmds/rtk/src/commands/apply.rs
@@ -269,12 +269,8 @@ pub async fn apply_environment<W: Write>(
 					);
 				}
 				Err(e) => {
-					return Err(anyhow::anyhow!(
-						"failed to apply {}/{}: {}",
-						diff.gvk.kind,
-						diff.name,
-						e
-					));
+					return Err(e)
+						.context(format!("failed to apply {}/{}", diff.gvk.kind, diff.name));
 				}
 			}
 		}

--- a/cmds/rtk/src/commands/prune.rs
+++ b/cmds/rtk/src/commands/prune.rs
@@ -242,12 +242,7 @@ pub async fn prune_environment<W: Write>(
 				deleted.push(diff.clone());
 			}
 			Err(e) => {
-				return Err(anyhow::anyhow!(
-					"failed to delete {}/{}: {}",
-					diff.gvk.kind,
-					diff.name,
-					e
-				));
+				return Err(e).context(format!("failed to delete {}/{}", diff.gvk.kind, diff.name));
 			}
 		}
 	}

--- a/cmds/rtk/tests/apply_test.rs
+++ b/cmds/rtk/tests/apply_test.rs
@@ -93,6 +93,71 @@ async fn run_apply_test(test_dir: &std::path::Path, discovery_mode: DiscoveryMod
 	);
 }
 
+/// Run an apply that expects a Kubernetes API write failure, and assert the
+/// underlying API message is preserved in the returned error chain.
+async fn run_apply_failure_preserves_api_error(test_dir: &std::path::Path) {
+	let env_dir = test_dir.join("environment");
+	let cluster_dir = test_dir.join("cluster");
+	let cluster_state = test_utils::load_manifests_from_dir(&cluster_dir);
+
+	let api_message =
+		"configmaps \"my-config\" is forbidden: User \"test\" cannot patch resource \"configmaps\"";
+	let fail_writes = serde_json::json!({
+		"kind": "Status",
+		"apiVersion": "v1",
+		"metadata": {},
+		"status": "Failure",
+		"message": api_message,
+		"reason": "Forbidden",
+		"code": 403
+	});
+
+	let server = k8s_mock::HttpMockK8sServer::builder()
+		.discovery_mode(DiscoveryMode::Aggregated)
+		.resources(cluster_state)
+		.fail_writes(fail_writes)
+		.build()
+		.start()
+		.await;
+
+	let spec = rtk::spec::Spec {
+		context_names: Some(vec!["mock-context".to_string()]),
+		..rtk::spec::Spec::default()
+	};
+	let connection =
+		rtk::k8s::client::ClusterConnection::from_spec_with_kubeconfig(&spec, server.kubeconfig())
+			.await
+			.expect("failed to create connection");
+
+	let mut output = Vec::new();
+	let opts = ApplyOpts {
+		auto_approve: AutoApprove::Always,
+		color: ColorMode::Never,
+		..Default::default()
+	};
+
+	let err = apply_environment(
+		env_dir.as_path(),
+		Some(connection),
+		GlobalEvaluatorOptions::default(),
+		EvaluatorOptions::default(),
+		opts,
+		&mut output,
+	)
+	.await
+	.expect_err("apply should fail when the API rejects writes");
+
+	let rendered = format!("{err:?}");
+	assert!(
+		rendered.contains(api_message),
+		"expected kube API message in error chain, got:\n{rendered}"
+	);
+	assert!(
+		rendered.contains("failed to apply ConfigMap/my-config"),
+		"expected apply context in error, got:\n{rendered}"
+	);
+}
+
 /// Run an apply test that expects no changes (idempotent case).
 ///
 /// The environment's manifests already match the cluster state.
@@ -179,4 +244,10 @@ mod tests {
 
 	// No-changes tests: cluster already matches environment
 	apply_no_changes_test!(configmap_unchanged);
+
+	#[tokio::test]
+	async fn apply_failure_preserves_kube_api_error() {
+		let test_dir = test_utils::diff_fixture_dir("configmap_modified");
+		run_apply_failure_preserves_api_error(&test_dir).await;
+	}
 }

--- a/crates/k8s-mock/src/http.rs
+++ b/crates/k8s-mock/src/http.rs
@@ -68,6 +68,9 @@ pub struct HttpMockK8sServer {
 	/// Values are OpenAPI schema JSON documents.
 	#[builder(default)]
 	openapi_schemas: HashMap<String, serde_json::Value>,
+	/// When set, non-dry-run PATCH/POST/DELETE return this Kubernetes Status body.
+	/// Dry-run requests still succeed so diff can complete before apply fails.
+	fail_writes: Option<serde_json::Value>,
 }
 
 /// A running HTTP mock server instance.
@@ -112,7 +115,7 @@ impl HttpMockK8sServer {
 
 		mount_version(&server, &exchanges).await;
 		mount_discovery(&server, &discovery, self.discovery_mode, &exchanges).await;
-		mount_resources(&server, &shared_resources, &exchanges).await;
+		mount_resources(&server, &shared_resources, &exchanges, self.fail_writes).await;
 		mount_openapi(&server, &self.openapi_schemas, &exchanges).await;
 
 		RunningHttpMockK8sServer { server, exchanges }
@@ -622,10 +625,21 @@ fn merge_type_from_content_type(req: &Request) -> MergeType {
 	}
 }
 
+fn write_failure_response(
+	exchanges: &SharedExchanges,
+	req: &Request,
+	status: &serde_json::Value,
+) -> ResponseTemplate {
+	let code = status.get("code").and_then(|c| c.as_u64()).unwrap_or(500) as u16;
+	record_exchange(exchanges, req, code, &status.to_string());
+	ResponseTemplate::new(code).set_body_json(status)
+}
+
 async fn mount_resources(
 	server: &MockServer,
 	resources: &SharedResources,
 	exchanges: &SharedExchanges,
+	fail_writes: Option<serde_json::Value>,
 ) {
 	let patch_resources = Arc::clone(resources);
 	let post_resources = Arc::clone(resources);
@@ -635,6 +649,9 @@ async fn mount_resources(
 	let post_exchanges = Arc::clone(exchanges);
 	let delete_exchanges = Arc::clone(exchanges);
 	let get_exchanges = Arc::clone(exchanges);
+	let patch_fail_writes = fail_writes.clone();
+	let post_fail_writes = fail_writes.clone();
+	let delete_fail_writes = fail_writes;
 
 	// PATCH endpoints - merge request body with existing resource
 	// If dry-run is not set, persist the changes
@@ -644,6 +661,12 @@ async fn mount_resources(
 			let path_str = req.url.path();
 			let query = req.url.query().unwrap_or("");
 			let is_dry_run = query.contains("dryRun");
+
+			if !is_dry_run {
+				if let Some(ref status) = patch_fail_writes {
+					return write_failure_response(&patch_exchanges, req, status);
+				}
+			}
 
 			let (api_path, name) = parse_resource_path(path_str);
 			let name = name.unwrap_or_default();
@@ -691,6 +714,12 @@ async fn mount_resources(
 			let query = req.url.query().unwrap_or("");
 			let is_dry_run = query.contains("dryRun");
 
+			if !is_dry_run {
+				if let Some(ref status) = post_fail_writes {
+					return write_failure_response(&post_exchanges, req, status);
+				}
+			}
+
 			let body: serde_json::Value =
 				serde_json::from_slice(&req.body).unwrap_or(serde_json::Value::Null);
 
@@ -718,6 +747,14 @@ async fn mount_resources(
 	Mock::given(method("DELETE"))
 		.and(path_regex(r"^/api(s)?/.*"))
 		.respond_with(move |req: &Request| {
+			let query = req.url.query().unwrap_or("");
+			let is_dry_run = query.contains("dryRun");
+			if !is_dry_run {
+				if let Some(ref status) = delete_fail_writes {
+					return write_failure_response(&delete_exchanges, req, status);
+				}
+			}
+
 			let path_str = req.url.path();
 			let (api_path, name) = parse_resource_path(path_str);
 			let name = name.unwrap_or_default();


### PR DESCRIPTION
## Summary

Surface the underlying Kubernetes API error when apply or prune fails, instead of only repeating the resource kind/name.

- Wrap apply/prune failures with `.context()` so the kube `#[source]` chain is preserved (previously lost by stringifying via `anyhow!("...: {}", e)`)

### Context

Failures printed like `failed to apply ConfigMap/foo: applying ConfigMap/foo` with no API reason (Forbidden, Invalid, etc.). The real `kube::Error` was on `ApplyError`'s source and got dropped when wrapping.


Made with [Cursor](https://cursor.com)