### PR TITLE
fix(jsonnet): evaluate nested object assertions

### DIFF
--- a/crates/jrsonnet-evaluator/src/obj/mod.rs
+++ b/crates/jrsonnet-evaluator/src/obj/mod.rs
@@ -416,6 +416,7 @@ struct ObjValueInner {
 
 thread_local! {
 	static RUNNING_ASSERTIONS: RefCell<FxHashSet<ObjValue>> = RefCell::default();
+	static SUPPRESSED_ASSERTIONS: RefCell<FxHashSet<ObjValue>> = RefCell::default();
 }
 fn has_running_assertions() -> bool {
 	RUNNING_ASSERTIONS.with_borrow(|v| !v.is_empty())
@@ -423,6 +424,28 @@ fn has_running_assertions() -> bool {
 /// Returns false if already asserting
 fn start_asserting(obj: &ObjValue) -> bool {
 	RUNNING_ASSERTIONS.with_borrow_mut(|v| v.insert(obj.clone()))
+}
+fn is_assertion_suppressed(obj: &ObjValue) -> bool {
+	SUPPRESSED_ASSERTIONS.with_borrow(|v| v.contains(obj))
+}
+struct AssertionSuppressionGuard {
+	obj: ObjValue,
+	inserted: bool,
+}
+impl AssertionSuppressionGuard {
+	fn new(obj: ObjValue) -> Self {
+		let inserted = SUPPRESSED_ASSERTIONS.with_borrow_mut(|v| v.insert(obj.clone()));
+		Self { obj, inserted }
+	}
+}
+impl Drop for AssertionSuppressionGuard {
+	fn drop(&mut self) {
+		if self.inserted {
+			SUPPRESSED_ASSERTIONS.with_borrow_mut(|v| {
+				v.remove(&self.obj);
+			});
+		}
+	}
 }
 // == Rustanka custom features ==
 
@@ -440,6 +463,7 @@ pub fn should_skip_assertions() -> bool {
 /// Resets all thread-local state in obj to defaults.
 pub fn reset_obj_thread_locals() {
 	RUNNING_ASSERTIONS.with_borrow_mut(|v| v.clear());
+	SUPPRESSED_ASSERTIONS.with_borrow_mut(|v| v.clear());
 	SKIP_ASSERTIONS.with(|v| v.set(false));
 }
 
@@ -820,20 +844,19 @@ impl ObjValue {
 				}
 			}
 		};
-		let result = self.get_idx_uncached(key, core, assertion_reentry);
+		// A pending field may be read by an assertion while that field is still being
+		// evaluated. Suppress assertions for that object until the re-entry unwinds,
+		// including any sibling fields needed to finish evaluating the pending field.
+		let _suppression = assertion_reentry.then(|| AssertionSuppressionGuard::new(self.clone()));
+		let result = self.get_idx_uncached(key, core);
 		{
 			let mut cache = self.0.value_cache.borrow_mut();
 			cache.insert(cache_key, CacheValue::Cached(result.clone()));
 		}
 		result
 	}
-	fn get_idx_uncached(
-		&self,
-		key: IStr,
-		core: CoreIdx,
-		assertion_reentry: bool,
-	) -> Result<Option<Val>> {
-		if !assertion_reentry {
+	fn get_idx_uncached(&self, key: IStr, core: CoreIdx) -> Result<Option<Val>> {
+		if !is_assertion_suppressed(self) {
 			self.run_assertions()?;
 		}
 		let mut first_add = None;

--- a/crates/jrsonnet-evaluator/src/obj/mod.rs
+++ b/crates/jrsonnet-evaluator/src/obj/mod.rs
@@ -417,9 +417,6 @@ struct ObjValueInner {
 thread_local! {
 	static RUNNING_ASSERTIONS: RefCell<FxHashSet<ObjValue>> = RefCell::default();
 }
-fn is_asserting(obj: &ObjValue) -> bool {
-	RUNNING_ASSERTIONS.with_borrow(|v| v.contains(obj))
-}
 fn has_running_assertions() -> bool {
 	RUNNING_ASSERTIONS.with_borrow(|v| !v.is_empty())
 }
@@ -804,32 +801,41 @@ impl ObjValue {
 
 	fn get_idx(&self, key: IStr, core: CoreIdx) -> Result<Option<Val>> {
 		let cache_key = (key.clone(), core);
-		{
+		let assertion_reentry = {
 			let mut cache = self.0.value_cache.borrow_mut();
 			// entry_ref candidate?
 			match cache.entry(cache_key.clone()) {
 				Entry::Occupied(v) => match v.get() {
 					CacheValue::Cached(v) => return v.clone(),
 					CacheValue::Pending => {
-						if !is_asserting(self) && !has_running_assertions() {
+						if !has_running_assertions() {
 							bail!(InfiniteRecursionDetected);
 						}
+						true
 					}
 				},
 				Entry::Vacant(v) => {
 					v.insert(CacheValue::Pending);
+					false
 				}
 			}
-		}
-		let result = self.get_idx_uncached(key, core);
+		};
+		let result = self.get_idx_uncached(key, core, assertion_reentry);
 		{
 			let mut cache = self.0.value_cache.borrow_mut();
 			cache.insert(cache_key, CacheValue::Cached(result.clone()));
 		}
 		result
 	}
-	fn get_idx_uncached(&self, key: IStr, core: CoreIdx) -> Result<Option<Val>> {
-		self.run_assertions()?;
+	fn get_idx_uncached(
+		&self,
+		key: IStr,
+		core: CoreIdx,
+		assertion_reentry: bool,
+	) -> Result<Option<Val>> {
+		if !assertion_reentry {
+			self.run_assertions()?;
+		}
 		let mut first_add = None;
 		let mut add_stack: Vec<Val> = Vec::new();
 		let mut skip = Saturating(0);

--- a/crates/jrsonnet-evaluator/src/obj/mod.rs
+++ b/crates/jrsonnet-evaluator/src/obj/mod.rs
@@ -420,6 +420,9 @@ thread_local! {
 fn is_asserting(obj: &ObjValue) -> bool {
 	RUNNING_ASSERTIONS.with_borrow(|v| v.contains(obj))
 }
+fn has_running_assertions() -> bool {
+	RUNNING_ASSERTIONS.with_borrow(|v| !v.is_empty())
+}
 /// Returns false if already asserting
 fn start_asserting(obj: &ObjValue) -> bool {
 	RUNNING_ASSERTIONS.with_borrow_mut(|v| v.insert(obj.clone()))
@@ -437,31 +440,10 @@ pub fn should_skip_assertions() -> bool {
 	SKIP_ASSERTIONS.with(|v| v.get())
 }
 
-// Feature 2: ASSERTION_DEPTH - prevents infinite recursion when assertions access fields
-thread_local! {
-	static ASSERTION_DEPTH: Cell<u32> = const { Cell::new(0) };
-}
-pub fn is_in_assertion() -> bool {
-	ASSERTION_DEPTH.with(|v| v.get() > 0)
-}
-struct AssertionGuard;
-impl AssertionGuard {
-	fn new() -> Self {
-		ASSERTION_DEPTH.with(|v| v.set(v.get() + 1));
-		AssertionGuard
-	}
-}
-impl Drop for AssertionGuard {
-	fn drop(&mut self) {
-		ASSERTION_DEPTH.with(|v| v.set(v.get() - 1));
-	}
-}
-
 /// Resets all thread-local state in obj to defaults.
 pub fn reset_obj_thread_locals() {
 	RUNNING_ASSERTIONS.with_borrow_mut(|v| v.clear());
 	SKIP_ASSERTIONS.with(|v| v.set(false));
-	ASSERTION_DEPTH.with(|v| v.set(0));
 }
 
 fn finish_asserting(obj: &ObjValue) {
@@ -829,7 +811,7 @@ impl ObjValue {
 				Entry::Occupied(v) => match v.get() {
 					CacheValue::Cached(v) => return v.clone(),
 					CacheValue::Pending => {
-						if !is_asserting(self) && !is_in_assertion() {
+						if !is_asserting(self) && !has_running_assertions() {
 							bail!(InfiniteRecursionDetected);
 						}
 					}
@@ -847,12 +829,7 @@ impl ObjValue {
 		result
 	}
 	fn get_idx_uncached(&self, key: IStr, core: CoreIdx) -> Result<Option<Val>> {
-		// If we're already inside an assertion evaluation, skip running assertions
-		// to avoid infinite recursion when assertions access fields on the same object.
-		// The assertions will complete when the original assertion evaluation finishes.
-		if !is_in_assertion() {
-			self.run_assertions()?;
-		}
+		self.run_assertions()?;
 		let mut first_add = None;
 		let mut add_stack: Vec<Val> = Vec::new();
 		let mut skip = Saturating(0);
@@ -969,16 +946,12 @@ impl ObjValue {
 		if should_skip_assertions() {
 			return Ok(());
 		}
-		if is_in_assertion() {
-			return Ok(());
-		}
 		if self.0.assertions_ran.get() {
 			return Ok(());
 		}
 		if !start_asserting(self) {
 			return Ok(());
 		}
-		let _guard = AssertionGuard::new();
 		let mut assertion_err: Option<crate::error::Error> = None;
 		self.0.cores.for_each_enumerated(&mut |idx, ele| {
 			if assertion_err.is_some() {

--- a/tests/suite/object_assertion.jsonnet
+++ b/tests/suite/object_assertion.jsonnet
@@ -1,3 +1,16 @@
 std.assertEqual({ assert 'a' in self : 'missing a' } + { a: 2 }, { a: 2 }) &&
 test.assertThrow({ assert 'a' in self : 'missing a', b: 1 }.b, 'assert failed: missing a') &&
+test.assertThrow(
+  {
+    _config: {
+      assert $.s3_credentials_eks_use_irsa || $.s3_credentials_vault_path != '' : 's3_credentials_vault_path must be specified',
+      overrides: {},
+    },
+    s3_credentials_eks_use_irsa: false,
+    s3_credentials_vault_path: '',
+    assert $._config.overrides == {},
+    internal_release_version: 'v1',
+  }.internal_release_version,
+  'assert failed: s3_credentials_vault_path must be specified',
+) &&
 true


### PR DESCRIPTION
## Summary

Match go-jsonnet when an object assertion accesses a field on another object.

- Run nested object assertions instead of suppressing all assertions while one is active
- Keep recursion protection scoped to objects currently evaluating assertions

Made with [Cursor](https://cursor.com)